### PR TITLE
Rename env var to prevent error

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -15,5 +15,5 @@ jobs:
       - name: Release
         run: cd .scripts && sh ./package.sh
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AUTHOR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REVIEWER_TOKEN: ${{ secrets.REVIEWER_TOKEN }}

--- a/.scripts/package.sh
+++ b/.scripts/package.sh
@@ -261,7 +261,7 @@ generate_swift_package () {
 }
 
 login_default() {
-    echo "$GITHUB_TOKEN" | gh auth login --with-token
+    echo "$AUTHOR_TOKEN" | gh auth login --with-token
 }
 
 login_reviewer() {


### PR DESCRIPTION
Using the GITHUB_TOKEN env var was causing an error because the gh cli uses that.